### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release policy
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false
 
@@ -25,7 +25,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
     with:
       oci-target: ghcr.io/kubewarden/tests/raw-validation-policy
       artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SOURCE_FILES := $(shell test -e src/ && find src -type f)
-VERSION := $(shell sed -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
 	cargo build --target=wasm32-wasip1 --release

--- a/metadata.yml
+++ b/metadata.yml
@@ -11,6 +11,7 @@ backgroundAudit: true
 annotations:
   # kubewarden specific:
   io.kubewarden.policy.title: raw-validation-policy
+  io.kubewarden.policy.version: 0.1.0
   io.kubewarden.policy.description: A policy that validates raw requests
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/yourorg/raw-validation-policy


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
Co-authored-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
